### PR TITLE
use repo version of mediainfo

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,58 +6,14 @@ ARG BUILD_DATE
 ARG VERSION
 LABEL build_version="Linuxserver.io version:- ${VERSION} Build-date:- ${BUILD_DATE}"
 
-# package version
-ARG MEDIAINF_VER="0.7.90"
-
-# install build packages
+# install packages
 RUN \
- apk add --no-cache --virtual=build-dependencies \
-	autoconf \
-	automake \
-	cppunit-dev \
-	curl-dev \
-	file \
-	g++ \
-	gcc \
-	libressl-dev \
-	libtool \
-	make \
-	ncurses-dev && \
-
-# compile mediainfo packages
- curl -o \
- /tmp/libmediainfo.tar.gz -L \
-	"http://mediaarea.net/download/binary/libmediainfo0/${MEDIAINF_VER}/MediaInfo_DLL_${MEDIAINF_VER}_GNU_FromSource.tar.gz" && \
- curl -o \
- /tmp/mediainfo.tar.gz -L \
-	"http://mediaarea.net/download/binary/mediainfo/${MEDIAINF_VER}/MediaInfo_CLI_${MEDIAINF_VER}_GNU_FromSource.tar.gz" && \
- mkdir -p \
-	/tmp/libmediainfo \
-	/tmp/mediainfo && \
- tar xf /tmp/libmediainfo.tar.gz -C \
-	/tmp/libmediainfo --strip-components=1 && \
- tar xf /tmp/mediainfo.tar.gz -C \
-	/tmp/mediainfo --strip-components=1 && \
-
- cd /tmp/libmediainfo && \
-	./SO_Compile.sh && \
- cd /tmp/libmediainfo/ZenLib/Project/GNU/Library && \
-	make install && \
- cd /tmp/libmediainfo/MediaInfoLib/Project/GNU/Library && \
-	make install && \
- cd /tmp/mediainfo && \
-	./CLI_Compile.sh && \
- cd /tmp/mediainfo/MediaInfo/Project/GNU/CLI && \
-	make install && \
+ apk add --no-cache \
+	--repository http://nl.alpinelinux.org/alpine/edge/testing \
+	mediainfo && \
 
 # install app
- git clone --depth=1 https://github.com/pymedusa/Medusa /app/medusa && \
-
-# cleanup
- apk del --purge \
-	build-dependencies && \
- rm -rf \
-	/tmp/*
+ git clone --depth=1 https://github.com/pymedusa/Medusa /app/medusa
 
 # copy local files
 COPY root/ /

--- a/README.md
+++ b/README.md
@@ -86,6 +86,7 @@ Web interface is at `<your ip>:8081` , set paths for downloads, tv-shows to matc
 
 ## Versions
 
++ **10.10.17:** Use repo version of mediainfo to shorten build time.
 + **05.08.17:** Internal git pull instead of at runtime.
 + **20.05.17:** Rebase to alpine 3.6.
 + **01.01.17:** Initial Release.


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]
	

<!--- Before submitting a pull request please check the following -->


<!---  That you have made a branch in your fork, we'd rather not merge from your master -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!---  -->

##  Thanks, team linuxserver.io

+ using repo version of mediainfo drastically cuts build time